### PR TITLE
Feature/stdout fix

### DIFF
--- a/mssql-scripter
+++ b/mssql-scripter
@@ -9,12 +9,7 @@ done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 # Set the python io encoding to UTF-8 by default if not set.
-if ["$PYTHONIOENCODING"=""]
-then
-  export PYTHONIOENCODING="UTF-8"
-  # Used as a flag to tell scripter we manually set the encoding.
-  export MSSQLSCRIPTER_DEFAULT_ENCODING="TRUE"
-fi
+if [ -z ${PYTHONIOENCODING+x} ]; then export PYTHONIOENCODING=utf8; fi
 
 export PYTHONPATH="${DIR}:${PYTHONPATH}"
 

--- a/mssql-scripter
+++ b/mssql-scripter
@@ -8,6 +8,14 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
+# Set the python io encoding to UTF-8 by default if not set.
+if ["$PYTHONIOENCODING"=""]
+then
+  export PYTHONIOENCODING="UTF-8"
+  # Used as a flag to tell scripter we manually set the encoding.
+  export MSSQLSCRIPTER_DEFAULT_ENCODING="TRUE"
+fi
+
 export PYTHONPATH="${DIR}:${PYTHONPATH}"
 
 python -m mssqlscripter "$@"

--- a/mssql-scripter.bat
+++ b/mssql-scripter.bat
@@ -3,8 +3,6 @@ setlocal
 REM Set the python io encoding to UTF-8 by default if not set.
 IF "%PYTHONIOENCODING%"=="" (
     SET PYTHONIOENCODING="UTF-8"
-    REM Used as a flag to tell scripter we manually set the encoding.
-    SET MSSQLSCRIPTER_DEFAULT_ENCODING="TRUE"
 )
 SET PYTHONPATH=%~dp0;%PYTHONPATH%
 python -m mssqlscripter %*

--- a/mssql-scripter.bat
+++ b/mssql-scripter.bat
@@ -1,6 +1,11 @@
 @echo off
 setlocal
-
+REM Set the python io encoding to UTF-8 by default if not set.
+IF "%PYTHONIOENCODING%"=="" (
+    SET PYTHONIOENCODING="UTF-8"
+    REM Used as a flag to tell scripter we manually set the encoding.
+    SET MSSQLSCRIPTER_DEFAULT_ENCODING="TRUE"
+)
 SET PYTHONPATH=%~dp0;%PYTHONPATH%
 python -m mssqlscripter %*
 

--- a/mssqlscripter/__main__.py
+++ b/mssqlscripter/__main__.py
@@ -20,9 +20,3 @@ except KeyboardInterrupt as error:
 except Exception as error:
     sys.stderr.write(str(error))
     sys.exit(3)
-finally:
-    # If MSSQLSCRIPTER_DEFAULT_ENCODING was set, it means we set the encoding ourselves,
-    # so we have to clean up and reset the variables.
-    if 'MSSQLSCRIPTER_DEFAULT_ENCODING' in os.environ:
-        os.environ['MSSQLSCRIPTER_DEFAULT_ENCODING']=""
-        os.environ['PYTHONIOENCODING']=""

--- a/mssqlscripter/__main__.py
+++ b/mssqlscripter/__main__.py
@@ -3,7 +3,6 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-import os
 import sys
 
 import mssqlscripter.main

--- a/mssqlscripter/__main__.py
+++ b/mssqlscripter/__main__.py
@@ -3,6 +3,7 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
+import os
 import sys
 
 import mssqlscripter.main
@@ -19,3 +20,9 @@ except KeyboardInterrupt as error:
 except Exception as error:
     sys.stderr.write(str(error))
     sys.exit(3)
+finally:
+    # If MSSQLSCRIPTER_DEFAULT_ENCODING was set, it means we set the encoding ourselves,
+    # so we have to clean up and reset the variables.
+    if 'MSSQLSCRIPTER_DEFAULT_ENCODING' in os.environ:
+        os.environ['MSSQLSCRIPTER_DEFAULT_ENCODING']=""
+        os.environ['PYTHONIOENCODING']=""

--- a/mssqlscripter/main.py
+++ b/mssqlscripter/main.py
@@ -92,7 +92,8 @@ def main(args):
                 scriptercallbacks.handle_response(response, parameters.DisplayProgress)
 
         # Only write to stdout if user did not provide a file path.
-        logger.info('stdout current encoding: {}'.format(os.environ["PYTHONIOENCODING"]))
+        logger.info('stdout current encoding: {}'.format(sys.stdout.encoding))
+        print(sys.stdout.encoding)
         if temp_file_path:
             with io.open(parameters.FilePath, encoding=u'utf-16') as script_file:
                 for line in script_file.readlines():

--- a/mssqlscripter/main.py
+++ b/mssqlscripter/main.py
@@ -92,17 +92,10 @@ def main(args):
                 scriptercallbacks.handle_response(response, parameters.DisplayProgress)
 
         # Only write to stdout if user did not provide a file path.
-        logger.info('stdout current encoding: {}'.format(sys.stdout.encoding))
+        logger.info('stdout current encoding: {}'.format(os.environ["PYTHONIOENCODING"]))
         if temp_file_path:
             with io.open(parameters.FilePath, encoding=u'utf-16') as script_file:
                 for line in script_file.readlines():
-                    # If piping, stdout encoding is none in python 2 which resolves to 'ascii'.
-                    # If it is not none then the user has specified a custom
-                    # encoding.
-                    if not sys.stdout.encoding:
-                        # We are piping and the user is using the default encoding,
-                        # so encode to utf8.
-                        line = line.encode(u'utf-8')
                     sys.stdout.write(line)
 
     finally:

--- a/mssqlscripter/main.py
+++ b/mssqlscripter/main.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(u'mssqlscripter.main')
 def main(args):
     """
         Main entry point to mssql-scripter.
-
     """
     scripterlogging.initialize_logger()
     logger.info('Python Information :{}'.format(sys.version_info))
@@ -93,7 +92,6 @@ def main(args):
 
         # Only write to stdout if user did not provide a file path.
         logger.info('stdout current encoding: {}'.format(sys.stdout.encoding))
-        print(sys.stdout.encoding)
         if temp_file_path:
             with io.open(parameters.FilePath, encoding=u'utf-16') as script_file:
                 for line in script_file.readlines():


### PR DESCRIPTION
Set the PYTHONIOENCODING if it is not set to UTF-8.

This solves the problem of handling the different encoding that can be set during run time which has different behaviors in Python 2 vs Python 3.