### PR TITLE
Update SqlToolsService with SMO post processing enabled fix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0a1
+current_version = 1.0.0a7
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>.*))(?P<release_version>\d+)
 serialize = 
 	{major}.{minor}.{patch}{release}{release_version}

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@
 .. image:: https://img.shields.io/pypi/pyversions/mssql-scripter.svg   
    :target: https://travis-ci.org/Microsoft/sql-xplat-cli
    
-mssql-scripter 1.0.0a1
+mssql-scripter 1.0.0a7
 ============================
 
 We’re excited to introduce mssql-scripter, a multi-platform command line

--- a/mssqlscripter/__init__.py
+++ b/mssqlscripter/__init__.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-__version__ = '1.0.0a1'
+__version__ = '1.0.0a7'

--- a/mssqltoolsservice/README.rst
+++ b/mssqltoolsservice/README.rst
@@ -1,4 +1,4 @@
-mssqltoolsservice 1.0.0a1
+mssqltoolsservice 1.0.0a7
 ===============================
 
 The platform specific mssqltoolsservice package provides external

--- a/mssqltoolsservice/buildwheels.py
+++ b/mssqltoolsservice/buildwheels.py
@@ -17,7 +17,7 @@ install_aliases()
 from urllib.request import urlopen
 
 
-DOWNLOAD_URL_BASE = 'https://mssqlscripter.blob.core.windows.net/sqltoolsservice-05-06-2017/'
+DOWNLOAD_URL_BASE = 'https://mssqlscripter.blob.core.windows.net/sqltoolsservice-05-24-2017/'
 
 # Supported platform key's must match those in mssqlscript's setup.py.
 SUPPORTED_PLATFORMS = {

--- a/mssqltoolsservice/mssqltoolsservice/__init__.py
+++ b/mssqltoolsservice/mssqltoolsservice/__init__.py
@@ -9,7 +9,7 @@
 import os
 import platform
 
-__version__ = '1.0.0a1'
+__version__ = '1.0.0a7'
 
 
 def get_executable_path():

--- a/mssqltoolsservice/setup.py
+++ b/mssqltoolsservice/setup.py
@@ -12,7 +12,7 @@ import sys
 
 # This version number is in place in two places and must be in sync with
 # mssqlscripter's version in setup.py.
-MSSQLTOOLSSERVICE_VERSION = '1.0.0a1'
+MSSQLTOOLSSERVICE_VERSION = '1.0.0a7'
 
 # If we have source, validate version numbers match to prevent
 # uploading releases with mismatched versions.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup
 
 # This version number is in place in two places and must be in sync with
 # mssqltoolsservice's version in setup.py.
-MSSQLSCRIPTER_VERSION = '1.0.0a1'
+MSSQLSCRIPTER_VERSION = '1.0.0a7'
 
 # If we have the source, validate our setup version matches source version.
 # This will prevent uploading releases with mismatched versions. This will

--- a/utility.py
+++ b/utility.py
@@ -5,8 +5,16 @@
 
 from __future__ import print_function
 from subprocess import check_call, CalledProcessError
+import os
 import shutil
 import sys
+
+
+MSSQLSCRIPTER_DIST_DIRECTORY = os.path.abspath(
+    os.path.join(os.path.abspath(__file__), '..', 'dist'))
+
+MSSQLTOOLSSERVICE_DIST_DIRECTORY = os.path.abspath(os.path.join(
+    os.path.abspath(__file__), '..', 'mssqltoolsservice', 'dist'))
 
 
 def exec_command(command, directory, continue_on_error=True):

--- a/verify_packaging.py
+++ b/verify_packaging.py
@@ -8,7 +8,9 @@ import utility
 import os
 import setup    # called via "verify_package.py clean"" to detect platform for wheel generation.
 
+
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
+
 
 def build_wheel_for_current_platform():
     """

--- a/verify_packaging.py
+++ b/verify_packaging.py
@@ -8,14 +8,7 @@ import utility
 import os
 import setup    # called via "verify_package.py clean"" to detect platform for wheel generation.
 
-
-MSSQLSCRIPTER_DIST_DIRECTORY = os.path.abspath(
-    os.path.join(os.path.abspath(__file__), '..', 'dist'))
-MSSQLTOOLSSERVICE_DIST_DIRECTORY = os.path.abspath(os.path.join(
-    os.path.abspath(__file__), '..', 'mssqltoolsservice', 'dist'))
-
 root_dir = os.path.abspath(os.path.join(os.path.abspath(__file__), '..'))
-
 
 def build_wheel_for_current_platform():
     """
@@ -35,7 +28,7 @@ def verify_local_install():
         Install mssql-scripter package locally that resolves mssqltoolsservice dependency from local build.
     """
     # Local install of mssql-scripter.
-    mssqlscripter_sdist_name = os.listdir(MSSQLSCRIPTER_DIST_DIRECTORY)[0]
+    mssqlscripter_sdist_name = os.listdir(utility.MSSQLSCRIPTER_DIST_DIRECTORY)[0]
     # To ensure we have a clean install, we disable the cache as to prevent cache overshadowing actual changes made.
     utility.exec_command(
         'pip install --no-cache-dir --no-index --find-links=./mssqltoolsservice/dist ./dist/{}'.format(mssqlscripter_sdist_name),


### PR DESCRIPTION
The current .NET Core version of SMO did not have the post processing feature. Without this feature, when scripting data, the following exception could be raised depending on the schema being scripted:

`System.MissingMethodException: Constructor on type 'Microsoft.SqlServer.Management.Smo.PostProcessUser' not found.
`

This change updates the .NET Core version of SMO with post processing feature enabled.

Also, including a fix that moves the MSSQLSCRIPTER_DIST_DIRECTORY and MSSQLTOOLSSERVICE_DIST_DIRECTORY constants to utility.py