### PR TITLE
Integrating readme_renderer into build and release process.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -19,7 +19,3 @@ values =
 
 [bumpversion:file:mssqltoolsservice/mssqltoolsservice/__init__.py]
 
-[bumpversion:file:README.rst]
-
-[bumpversion:file:mssqltoolsservice/README.rst]
-

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include LICENSE.txt
-include requirements.txt
 include README.rst

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@
 .. image:: https://img.shields.io/pypi/pyversions/mssql-scripter.svg
     :target: https://travis-ci.org/Microsoft/sql-xplat-cli
 
-mssql-scripter 1.0.0a11
-============================
+mssql-scripter
+===============
 We’re excited to introduce mssql-scripter, a multi-platform command line
 experience for scripting SQL Server databases.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
       PYTHON: "C:\\Python36"
 
 install:
-  - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip install -r dev_requirements.txt"
   - "%PYTHON%\\python.exe -m pip install codecov" 
 build: off
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,11 +1,8 @@
-# Requirements for both dev and production.
 enum34 >= 1.1.6
 future >= 0.16.0
 setuptools >= 36.0.1
 requests >= 2.13.0
 wheel >= 0.29.0
-
-#Development requirements.
 coverage >= 4.3.4
 twine >= 1.8.1
 bumpversion >= 0.5.3 

--- a/dev_setup.py
+++ b/dev_setup.py
@@ -18,7 +18,7 @@ print('Running dev setup...')
 print('Root directory \'{}\'\n'.format(root_dir))
 
 # install general requirements.
-utility.exec_command('pip install -r requirements.txt', root_dir)
+utility.exec_command('pip install -r dev_requirements.txt', root_dir)
 
 # install mssqltoolsservice if this platform supports it.
 mssqltoolsservice_package_name = os.environ['MSSQLTOOLSSERVICE_PACKAGE_NAME']

--- a/doc/pypi_release_steps.md
+++ b/doc/pypi_release_steps.md
@@ -48,9 +48,9 @@ bumpversion release_version    ->  1.0.0a<b>1</b>
       rm -rf dist
       rm -rf mssqltoolsservice/dist
       ```
-2. Build mssql-scripter source distribution, From `<clone_root>` execute:
+2. Build mssql-scripter source distribution and verify readme.rst, From `<clone_root>` execute:
     ```
-    python setup.py sdist
+    python setup.py check -r -s sdist
     ```
 
 3. Build mssqltoolsservice wheels for each supported platform, From `<clone_root>/mssqltoolsservice` execute:
@@ -91,8 +91,6 @@ bumpversion release_version    ->  1.0.0a<b>1</b>
 		password = your_password
         ```
 4. Register and upload to pypi test server:
-    
-    
     
     ```
     python register_upload.py register pypitest

--- a/mssqltoolsservice/README.rst
+++ b/mssqltoolsservice/README.rst
@@ -1,17 +1,17 @@
-mssqltoolsservice 1.0.0a11
-===============================
+mssqltoolsservice
+=================
 
 The platform specific mssqltoolsservice package provides external
 dependencies to the mssql-scripter tool.
 
 Installing this standalone package will not provide any functionality.
 This package is not recommended to be installed directly via pip and
-should only be handled via mssql-scipter’s install.
+should only be handled via mssql-scripter’s install.
 
 Support is not provided to this package alone.
 
-`Microsoft SQL Tools Service GitHub`_
-`mssql-scriper GitHub repository`_
+`Microsoft SQL Tools Service GitHub repository`_
+`mssql-scripter GitHub repository`_
 
 .. _Microsoft SQL Tools Service GitHub repository: https://github.com/Microsoft/sqltoolsservice
-.. _mssql-scriper GitHub repository: https://github.com/Microsoft/sql-xplat-cli
+.. _mssql-scripter GitHub repository: https://github.com/Microsoft/sql-xplat-cli

--- a/mssqltoolsservice/buildwheels.py
+++ b/mssqltoolsservice/buildwheels.py
@@ -79,7 +79,7 @@ def build_sqltoolsservice_wheels(platforms):
 
         print(u'Calling setup bdist_wheel for platform:{}'.format(platform))
         download_and_unzip(SUPPORTED_PLATFORMS[platform], directory=TARGET_DIRECTORY)
-        utility.exec_command(u'python setup.py bdist_wheel', CURRENT_DIRECTORY)
+        utility.exec_command(u'python setup.py check -r -s bdist_wheel', CURRENT_DIRECTORY)
 
         print(u'Cleaning up mssqltoolservice and build directory for platform:{}'.format(platform))
         utility.clean_up(directory=TARGET_DIRECTORY)

--- a/mssqltoolsservice/setup.py
+++ b/mssqltoolsservice/setup.py
@@ -63,6 +63,7 @@ setup(
     author_email='sqlxplatclieng@microsoft.com',
     url='https://github.com/Microsoft/sqltoolsservice',
     zip_safe=True,
+    long_description=open('README.rst').read(),
     classifiers=CLASSIFIERS,
     include_package_data=True,
     packages=[

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Requirements for both dev and production.
 enum34 >= 1.1.6
 future >= 0.16.0
-setuptools >= 30.4.0
+setuptools >= 36.0.1
 requests >= 2.13.0
 wheel >= 0.29.0
 
@@ -13,3 +13,5 @@ tox >= 2.7.0
 flake8 >= 3.3.0
 pytest >= 3.0.7
 pytest-cov >= 2.5.1
+readme_renderer >= 17.2
+docutils >= 0.13.1

--- a/tox.ini
+++ b/tox.ini
@@ -25,10 +25,10 @@ commands=
     # Run unit tests with code coverage.
     pytest --cov-report xml --cov mssqlscripter
 
-    # Build mssql-scripter sdist.
-    python setup.py sdist
+    # Verify readme.rst and build mssql-scripter sdist.
+    python setup.py check -r -s sdist
 
-    # Build mssqltoolsservice wheel and install mssq-scripter.
+    # Verify readme.rst, build mssqltoolsservice wheel, and install mssql-scripter.
     python verify_packaging.py clean
 
     python -m mssqlscripter -h

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     PYTHONIOENCODING=utf-8
 
 deps=
-    -rrequirements.txt
+    -rdev_requirements.txt
 
 install_commands = 
 commands=


### PR DESCRIPTION
Adding support for readme_renderer which relies on updated setuptools and docutils.
Removed version numbers from readme's for both mssqltoolsservice and mssqlscripter.
Added 'check -r -s' to our setup logic to ensure we catch any failures in readme formatting locally or in CI builds rather than on pypitest.