### PR TITLE
Fixing scripting option: TargetDatabaseEngineType and updating mssqlt…

### DIFF
--- a/mssqlscripter/argparser.py
+++ b/mssqlscripter/argparser.py
@@ -281,7 +281,7 @@ def parse_arguments(args):
 
     parser.add_argument(
         u'--database-engine-type',
-        dest=u'ScriptForTheDatabaseEngineType',
+        dest=u'TargetDatabaseEngineType',
         # This parameter is determined based on engine edition and version in
         # the background. User cannot select it.
         action=u'store_const',
@@ -454,15 +454,15 @@ def map_server_options(parameters):
     # When targetting Azure, only the edition matters.
     if u'Azure' in target_server_version:
         # SMO ignores this value when it is targetting Azure.
-        parameters.ScriptCompatibilityOption = u'Script140Compat'
+        parameters.ScriptCompatibilityOption = u'Script105Compat'
         parameters.TargetDatabaseEngineEdition = azure_server_edition_map[
             target_server_version]
-        parameters.ScriptForTheDatabaseEngineType = u'SqlAzure'
+        parameters.TargetDatabaseEngineType = u'SqlAzure'
 
     else:
         parameters.ScriptCompatibilityOption = on_prem_server_version_map[target_server_version]
         parameters.TargetDatabaseEngineEdition = on_prem_server_edition_map[
             target_server_edition]
-        parameters.ScriptForTheDatabaseEngineType = u'SingleInstance'
+        parameters.TargetDatabaseEngineType = u'SingleInstance'
 
     return parameters

--- a/mssqlscripter/jsonrpc/contracts/scriptingservice.py
+++ b/mssqlscripter/jsonrpc/contracts/scriptingservice.py
@@ -162,7 +162,7 @@ class ScriptingOptions(object):
             u'ScriptCreate',
             u'ScriptDrop',
             u'ScriptCreateDrop'],
-        u'ScriptForTheDatabaseEngineType': [
+        u'TargetDatabaseEngineType': [
             u'SingleInstance',
             u'SqlAzure'],
         u'ScriptStatistics': [
@@ -224,7 +224,7 @@ class ScriptingOptions(object):
         # Scripting options that are limited.
         self.TypeOfDataToScript = u'SchemaOnly'
         self.ScriptDropAndCreate = u'ScriptCreate'
-        self.ScriptForTheDatabaseEngineType = u'SingleInstance'
+        self.TargetDatabaseEngineType = u'SingleInstance'
         self.ScriptStatistics = u'ScriptStatsNone'
         self.ScriptCompatibilityOption = u'Script140Compat'
         self.TargetDatabaseEngineEdition = u'SqlServerStandardEdition'

--- a/mssqlscripter/jsonrpc/contracts/tests/test_scripting.py
+++ b/mssqlscripter/jsonrpc/contracts/tests/test_scripting.py
@@ -166,7 +166,7 @@ class ScriptingRequestTests(unittest.TestCase):
             u'ScriptUniqueKeys': False,
             u'TypeOfDataToScript': u'SchemaOnly',
             u'ScriptDropAndCreate': u'ScriptCreate',
-            u'ScriptForTheDatabaseEngineType': u'SingleInstance',
+            u'TargetDatabaseEngineType': u'SingleInstance',
             u'ScriptStatistics': u'ScriptStatsNone',
             u'ScriptCompatibilityOption': u'Script140Compat',
             u'TargetDatabaseEngineEdition': u'SqlServerStandardEdition'}
@@ -218,7 +218,7 @@ class ScriptingRequestTests(unittest.TestCase):
             u'ScriptUniqueKeys': False,
             u'TypeOfDataToScript': u'SchemaOnly',
             u'ScriptDropAndCreate': u'ScriptCreate',
-            u'ScriptForTheDatabaseEngineType': u'SingleInstance',
+            u'TargetDatabaseEngineType': u'SingleInstance',
             u'ScriptStatistics': u'ScriptStatsNone',
             u'ScriptCompatibilityOption': u'Script140Compat',
             u'TargetDatabaseEngineEdition': u'SqlServerStandardEdition'}
@@ -282,7 +282,7 @@ class ScriptingRequestTests(unittest.TestCase):
             u'ScriptUniqueKeys': False,
             u'TypeOfDataToScript': u'SchemaOnly',
             u'ScriptDropAndCreate': u'ScriptCreate',
-            u'ScriptForTheDatabaseEngineType': u'SingleInstance',
+            u'TargetDatabaseEngineType': u'SingleInstance',
             u'ScriptStatistics': u'ScriptStatsNone',
             u'ScriptCompatibilityOption': u'Script140Compat',
             u'TargetDatabaseEngineEdition': u'SqlServerStandardEdition'}

--- a/mssqltoolsservice/buildwheels.py
+++ b/mssqltoolsservice/buildwheels.py
@@ -17,7 +17,7 @@ install_aliases()
 from urllib.request import urlopen
 
 
-DOWNLOAD_URL_BASE = 'https://mssqlscripter.blob.core.windows.net/sqltoolsservice-05-24-2017/'
+DOWNLOAD_URL_BASE = 'https://mssqlscripter.blob.core.windows.net/sqltoolsservice-06-13-2017/'
 
 # Supported platform key's must match those in mssqlscript's setup.py.
 SUPPORTED_PLATFORMS = {


### PR DESCRIPTION
ScriptForDatabaseEngineType did not match to enum TargetDatabaseEngineType.

This also pulls in the fix on the mssqltoolsservice side which included reordering of target database engine edition and type.