### PR TITLE
Fixing check for file path parameter.

### DIFF
--- a/mssqlscripter/argparser.py
+++ b/mssqlscripter/argparser.py
@@ -414,7 +414,6 @@ def parse_arguments(args):
         version='{}'.format(mssqlscripter.__version__))
 
     parameters = parser.parse_args(args)
-
     verify_directory(parameters)
 
     if parameters.Server:
@@ -426,7 +425,6 @@ def parse_arguments(args):
             sys.exit()
 
     map_server_options(parameters)
-
     return parameters
 
 
@@ -434,11 +432,11 @@ def verify_directory(parameters):
     """
         If creating a file per object, create the directory if it does not exist.
     """
+
     target_directory = parameters.FilePath
-    if parameters.ScriptDestination is 'ToFilePerObject':
+    if parameters.ScriptDestination == 'ToFilePerObject':
         if not os.path.exists(target_directory):
             os.makedirs(target_directory)
-
         # Give warning to user that target directory was not empty.
         if os.listdir(target_directory):
             sys.stdout.write(u'warning: Target directory {} was not empty.'.format(target_directory))

--- a/mssqlscripter/main.py
+++ b/mssqlscripter/main.py
@@ -44,7 +44,8 @@ def main(args):
     logger.info(scrubbed_parameters)
 
     temp_file_path = None
-    if not parameters.FilePath and parameters.ScriptDestination is 'ToSingleFile':
+
+    if not parameters.FilePath and parameters.ScriptDestination == 'ToSingleFile':
         # Generate and track the temp file.
         temp_file_path = tempfile.NamedTemporaryFile(
             prefix=u'mssqlscripter_', delete=False).name


### PR DESCRIPTION
Fixing equality check for script destination. 

Python 2.7 requires explicit checks with "==" versus python 3.6 which accepts "is".

Manually tested