### PR TITLE
Updating Sqltoolsservice and changing compat level to 130

### DIFF
--- a/mssqlscripter/argparser.py
+++ b/mssqlscripter/argparser.py
@@ -509,7 +509,8 @@ def map_server_options(parameters):
     # When targetting Azure, only the edition matters.
     if u'Azure' in target_server_version:
         # SMO ignores this value when it is targetting Azure.
-        parameters.ScriptCompatibilityOption = u'Script105Compat'
+        # SMO requires 120 compat or higher when scripting Azure or AzureDW.
+        parameters.ScriptCompatibilityOption = u'Script130Compat'
         parameters.TargetDatabaseEngineEdition = azure_server_edition_map[
             target_server_version]
         parameters.TargetDatabaseEngineType = u'SqlAzure'

--- a/mssqlscripter/argparser.py
+++ b/mssqlscripter/argparser.py
@@ -508,7 +508,6 @@ def map_server_options(parameters):
     target_server_edition = parameters.TargetDatabaseEngineEdition
     # When targetting Azure, only the edition matters.
     if u'Azure' in target_server_version:
-        # SMO ignores this value when it is targetting Azure.
         # SMO requires 120 compat or higher when scripting Azure or AzureDW.
         parameters.ScriptCompatibilityOption = u'Script130Compat'
         parameters.TargetDatabaseEngineEdition = azure_server_edition_map[

--- a/mssqltoolsservice/buildwheels.py
+++ b/mssqltoolsservice/buildwheels.py
@@ -17,7 +17,7 @@ install_aliases()
 from urllib.request import urlopen
 
 
-DOWNLOAD_URL_BASE = 'https://mssqlscripter.blob.core.windows.net/sqltoolsservice-07-12-2017/'
+DOWNLOAD_URL_BASE = 'https://mssqlscripter.blob.core.windows.net/sqltoolsservice-07-26-2017/'
 
 # Supported platform key's must match those in mssqlscript's setup.py.
 SUPPORTED_PLATFORMS = {


### PR DESCRIPTION
Picking up latest sqltoolsservice with correct SMO bits which contains:
- UTF-8 Default encoding
- Public PostProcessUser constructor

Updating default compat to 130 when scripting Azure or AzureDW .