### PR TITLE
Fix for Azure SQL Data Warehouse

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.0.0a15
+current_version = 1.0.0a18
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>.*))(?P<release_version>\d+)
 serialize = 
 	{major}.{minor}.{patch}{release}{release_version}

--- a/mssqlscripter/__init__.py
+++ b/mssqlscripter/__init__.py
@@ -3,4 +3,4 @@
 # Licensed under the MIT License. See License.txt in the project root for license information.
 # --------------------------------------------------------------------------------------------
 
-__version__ = '1.0.0a15'
+__version__ = '1.0.0a18'

--- a/mssqltoolsservice/buildwheels.py
+++ b/mssqltoolsservice/buildwheels.py
@@ -17,7 +17,7 @@ install_aliases()
 from urllib.request import urlopen
 
 
-DOWNLOAD_URL_BASE = 'https://mssqlscripter.blob.core.windows.net/sqltoolsservice-07-26-2017/'
+DOWNLOAD_URL_BASE = 'https://mssqlscripter.blob.core.windows.net/sqltoolsservice-08-01-2017/'
 
 # Supported platform key's must match those in mssqlscript's setup.py.
 SUPPORTED_PLATFORMS = {

--- a/mssqltoolsservice/mssqltoolsservice/__init__.py
+++ b/mssqltoolsservice/mssqltoolsservice/__init__.py
@@ -9,7 +9,7 @@
 import os
 import platform
 
-__version__ = '1.0.0a15'
+__version__ = '1.0.0a18'
 
 
 def get_executable_path():

--- a/mssqltoolsservice/setup.py
+++ b/mssqltoolsservice/setup.py
@@ -12,7 +12,7 @@ import sys
 
 # This version number is in place in two places and must be in sync with
 # mssqlscripter's version in setup.py.
-MSSQLTOOLSSERVICE_VERSION = '1.0.0a15'
+MSSQLTOOLSSERVICE_VERSION = '1.0.0a18'
 
 # If we have source, validate version numbers match to prevent
 # uploading releases with mismatched versions.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup
 
 # This version number is in place in two places and must be in sync with
 # mssqltoolsservice's version in setup.py.
-MSSQLSCRIPTER_VERSION = '1.0.0a15'
+MSSQLSCRIPTER_VERSION = '1.0.0a18'
 
 # If we have the source, validate our setup version matches source version.
 # This will prevent uploading releases with mismatched versions. This will


### PR DESCRIPTION
This PR bump the mssql-scripter version to a18 and the sqltoolsservice version that contains the fix for scripting Azure SQL Data Warehouse. The underlying issue was Azure SQL Data Warehouse does not support the `select @@servername`, so we now use `select SERVERPROPERTY('ServerName')` for Azure SQL Data Warehouse.