### PR TITLE
Fix perf issue where main event loop takes 100% of CPU

### DIFF
--- a/mssqlscripter/main.py
+++ b/mssqlscripter/main.py
@@ -87,7 +87,7 @@ def main(args):
 
         while not scripting_request.completed():
             # The sleep prevents burning up the CPU and lets other threads get scheduled.
-            time.sleep(0.1) 
+            time.sleep(0.1)
             response = scripting_request.get_response()
             if response:
                 scriptercallbacks.handle_response(response, parameters.DisplayProgress)

--- a/mssqlscripter/main.py
+++ b/mssqlscripter/main.py
@@ -86,8 +86,9 @@ def main(args):
         scripting_request.execute()
 
         while not scripting_request.completed():
+            # The sleep prevents burning up the CPU and lets other threads get scheduled.
+            time.sleep(0.1) 
             response = scripting_request.get_response()
-
             if response:
                 scriptercallbacks.handle_response(response, parameters.DisplayProgress)
 

--- a/sql-xplat-cli.pyproj
+++ b/sql-xplat-cli.pyproj
@@ -48,6 +48,7 @@
     <Content Include=".travis.yml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="build.py" />
     <Compile Include="dev_setup.py" />
     <Compile Include="mssqlscripter\argparser.py" />
     <Compile Include="mssqlscripter\jsonrpc\contracts\scriptingservice.py" />

--- a/sql-xplat-cli.pyproj
+++ b/sql-xplat-cli.pyproj
@@ -11,8 +11,6 @@
     <OutputPath>.</OutputPath>
     <ProjectTypeGuids>{888888a0-9f3d-457c-b088-3a5042f75d52}</ProjectTypeGuids>
     <LaunchProvider>Standard Python launcher</LaunchProvider>
-    <InterpreterId />
-    <InterpreterVersion />
     <CommandLineArguments>-S localhost -d AdventureWorks2014</CommandLineArguments>
     <EnableNativeCodeDebugging>False</EnableNativeCodeDebugging>
     <IsWindowsApplication>False</IsWindowsApplication>
@@ -21,10 +19,11 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'" />
   <PropertyGroup>
     <VisualStudioVersion Condition=" '$(VisualStudioVersion)' == '' ">10.0</VisualStudioVersion>
-    <PtvsTargetsFile>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets</PtvsTargetsFile>
   </PropertyGroup>
   <ItemGroup>
     <Content Include=".gitignore" />
+    <Content Include="appveyor.yml" />
+    <Content Include="dev_requirements.txt" />
     <Content Include="doc\README.md" />
     <Content Include="doc\architecture_guide.md" />
     <Content Include="doc\development_guide.md" />
@@ -43,7 +42,6 @@
     <Content Include="mssqltoolsservice\README.rst" />
     <Content Include="mssqltoolsservice\setup.cfg" />
     <Content Include="README.rst" />
-    <Content Include="requirements.txt" />
     <Content Include="setup.cfg" />
     <Content Include="tox.ini" />
     <Content Include=".bumpversion.cfg" />
@@ -87,6 +85,5 @@
     <Folder Include="mssqltoolsservice\" />
     <Folder Include="mssqltoolsservice\mssqltoolsservice\" />
   </ItemGroup>
-  <Import Project="$(PtvsTargetsFile)" Condition="Exists($(PtvsTargetsFile))" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition="!Exists($(PtvsTargetsFile))" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\Python Tools\Microsoft.PythonTools.targets" />
 </Project>

--- a/sql-xplat-cli.sln
+++ b/sql-xplat-cli.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "sql-xplat-cli", "sql-xplat-cli.pyproj", "{F4BB6290-43F3-4F35-B26E-067C5EF8E64B}"
 EndProject
@@ -16,5 +16,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1A0F24BB-2803-4A8C-9816-CB374FAAC673}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
We have a 2 threads:
Thread 1 runs in a loop polling the response queue
Thread 2 runs in a loop decoding responses from the sqltoolsservice over stdout and posting them to the response queue

Since thread 1 doesn't sleep, it's takes 100% CPU. In addition, running python 2.7 on windows, thread 2 doesn’t preempt the CPU due to thread 1 taking all of the CPU cycles, so no response is processed.

Fix is simple – thread 1 needs to sleep so thread 2 can get scheduled and get it’s work done.