### PR TITLE
Fixing resource warning for sqltoolsservice

### DIFF
--- a/mssqlscripter/main.py
+++ b/mssqlscripter/main.py
@@ -105,7 +105,7 @@ def main(args):
         sql_tools_client.shutdown()
         tools_service_process.kill()
         # 1 second time out, allow tools service process to be killed.
-        time.sleep(1)
+        time.sleep(.1)
         # Close the stdout file handle or else we would get a resource warning (found via pytest).
         # This must be closed after the process is killed, otherwise we would block because the process is using
         # it's stdout.

--- a/mssqlscripter/main.py
+++ b/mssqlscripter/main.py
@@ -106,6 +106,10 @@ def main(args):
         tools_service_process.kill()
         # 1 second time out, allow tools service process to be killed.
         time.sleep(1)
+        # Close the stdout file handle or else we would get a resource warning (found via pytest).
+        # This must be closed after the process is killed, otherwise we would block because the process is using
+        # it's stdout.
+        tools_service_process.stdout.close()
         # None value indicates process has not terminated.
         if not tools_service_process.poll():
             sys.stderr.write(


### PR DESCRIPTION
After killing the toolsservice, the file handle for it's stdout is left unclosed.
This was discovered from running tests that uses the toolsservice in another project.